### PR TITLE
Implement exporting raw data

### DIFF
--- a/lib/mixpanel_data_client.ex
+++ b/lib/mixpanel_data_client.ex
@@ -34,7 +34,7 @@ defmodule MixpanelDataClient do
   defp handle_response(response, type \\ :json)
   defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: 200}}, :jsonl) do
     res = body
-    |> String.splint("\n")
+    |> String.split("\n")
     |> Enum.map(fn(item) -> Poison.decode! item end)
     { :ok, res }
   end

--- a/lib/mixpanel_data_client.ex
+++ b/lib/mixpanel_data_client.ex
@@ -1,7 +1,7 @@
 defmodule MixpanelDataClient do
   use HTTPoison.Base
   @base_url "http://mixpanel.com/api/2.0/"
-  @export_url "https://data.mixpanel.com/api/2.0/export"
+  @export_url "http://data.mixpanel.com/api/2.0/export"
 
   @doc """
     Fetch data from the mixpanel data api.
@@ -33,10 +33,15 @@ defmodule MixpanelDataClient do
 
   defp handle_response(response, type \\ :json)
   defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: 200}}, :jsonl) do
-    res = body
-    |> String.split("\n")
-    |> Enum.map(fn(item) -> Poison.decode! item end)
-    { :ok, res }
+    case body == "" do
+      true -> { :ok, []}
+      false -> 
+        res = body
+          |> String.strip
+          |> String.split("\n")
+          |> Enum.map(fn(item) -> Poison.decode! item end)
+        {:ok, res}
+    end
   end
   defp handle_response({:ok, %HTTPoison.Response{body: body, status_code: 200}}, :json) do
     { :ok, Poison.decode!(body) }

--- a/lib/mixpanel_data_client.ex
+++ b/lib/mixpanel_data_client.ex
@@ -20,7 +20,7 @@ defmodule MixpanelDataClient do
       => %{"data" => %{...}}
     ```
   """
-  @spec fetch(String.t, map(), {String.t, String.t}) :: {:error, map()} | {:ok, map()}
+  @spec fetch(String.t, map(), {String.t, String.t}) :: {:error, map()} | {:ok, map()} | {:ok, list()}
   def fetch("export" = endpoint, params, {key, secret}) do
     mixpanel_uri(endpoint, params, key, secret, expire())
     |> HTTPoison.get


### PR DESCRIPTION
This adds support for [exporting raw data](https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel)

Because the export endpoint is returning `jsonl`, the response has to be handled slightly different.
